### PR TITLE
test impl

### DIFF
--- a/math/src/elliptic_curve/short_weierstrass/curves/bandersnatch/curve.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bandersnatch/curve.rs
@@ -18,8 +18,8 @@ impl IsEllipticCurve for BandersnatchCurve {
     // Values are from https://github.com/arkworks-rs/curves/blob/5a41d7f27a703a7ea9c48512a4148443ec6c747e/ed_on_bls12_381_bandersnatch/src/curves/mod.rs#L120
     fn generator() -> Self::PointRepresentation {
         Self::PointRepresentation::new([
-            FieldElement::<Self::BaseField>::new_base("30900340493481298850216505686589334086208278925799850409469406976849338430199"),
-            FieldElement::<Self::BaseField>::new_base("12663882780877899054958035777720958383845500985908634476792678820121468453298"),
+            FieldElement::<Self::BaseField>::new_base("4450F9122AE57D5CBD002014EF530AD63F83A04D7022AEAD47AC4AEA0A73F2F7"),
+            FieldElement::<Self::BaseField>::new_base("1BFF80EF062FE4B1592598412A2B272627F74E164A63E0BE795A3EB57763C1B2"),
             FieldElement::one()
         ])
     }
@@ -27,39 +27,60 @@ impl IsEllipticCurve for BandersnatchCurve {
 
 impl IsShortWeierstrass for BandersnatchCurve {
     fn a() -> FieldElement<Self::BaseField> {
-        FieldElement::<Self::BaseField>::new_base("10773120815616481058602537765553212789256758185246796157495669123169359657269")
+        FieldElement::<Self::BaseField>::new_base("17D15ECBE9F0FC8B8C4A118E26DA26E5E32913D24F20541DE0720F8033267935")
     }
 
     fn b() -> FieldElement<Self::BaseField> {
-        FieldElement::<Self::BaseField>::new_base("29569587568322301171008055308580903175558631321415017492731745847794083609535")
+        FieldElement::<Self::BaseField>::new_base("415FCB20D12E60A811194E6B4D5D4625FA2D24F0AB8C256907BB3D28D5E8BBBF")
     }
 }
 
-// #[cfg(test)]
-// mod tests {
 
-//     use super::*;
-//     use crate::{
-//         cyclic_group::IsGroup, elliptic_curve::traits::EllipticCurveError,
-//         field::element::FieldElement,
-//     };
+#[cfg(test)]
+mod tests {
 
-//     use super::FqField;
+    use super::*;
+    use crate::{
+        cyclic_group::IsGroup, elliptic_curve::{traits::EllipticCurveError, montgomery::point},
+        field::element::FieldElement,
+    };
 
-//     #[allow(clippy::upper_case_acronyms)]
-//     type FEE = FieldElement<FqField>;
+    use super::FqField;
 
-//     fn point_1() -> ShortWeierstrassProjectivePoint<BandersnatchCurve> {
-//         let x = FEE::new_base("30900340493481298850216505686589334086208278925799850409469406976849338430199");
-//         let y = FEE::new_base("12663882780877899054958035777720958383845500985908634476792678820121468453298");    
-        
-//         BandersnatchCurve::create_point_from_affine(x, y).unwrap()
-//         }
-    
-//     fn point_1_times_5() -> ShortWeierstrassProjectivePoint<BandersnatchCurve> {
-//         let x = FEE::new_base("30900340493481298850216505686589334086208278925799850409469406976849338430199");
-//         let y = FEE::new_base("12663882780877899054958035777720958383845500985908634476792678820121468453298");    
-        
-//         BandersnatchCurve::create_point_from_affine(x, y).unwrap().mul(&5)
-//         }
-// }
+    #[allow(clippy::upper_case_acronyms)]
+    type FEE = FieldElement<BaseBandersnatchFieldElement>;
+
+    fn point_1() -> ShortWeierstrassProjectivePoint<BandersnatchCurve> {
+        let x = FEE::new_base("9697B44AA99E68EA78A5E48044A88E43B4ECF5D3B1833BEA4ED1F96653C4FC2");
+        let y = FEE::new_base("393C141D1A492C2289B2528D0C468EEB87FAF4C35964D2470EB262F76B3E0C8");    
+
+        BandersnatchCurve::create_point_from_affine(x, y).unwrap()
+        }
+
+    fn f1f2g_fixed() -> ShortWeierstrassProjectivePoint<BandersnatchCurve> {
+        let x = FEE::new_base("248BED2600CB615A6715105E8C33A48E2669775385260EDCCFFA0540A9204865");
+        let y = FEE::new_base("5DEB792D33432583D251F8EE85F7090A7BDDBC2113A10323650361F99BAF7254");    
+
+        BandersnatchCurve::create_point_from_affine(x, y).unwrap()
+        }
+
+    #[test]
+    fn test_scalar_mul() -> () {
+        let f1f2 = point_1();
+
+        let g = BandersnatchCurve::generator();
+        // let f1f2g = EdwardsAffine::from_str(
+        //     "(16530491029447613915334753043669938793793987372416328257719459807614119987301, \
+        //      42481140308370805476764840229335460092474682686441442216596889726548353970772)",
+        // )
+        // .unwrap();
+
+        // let f1f2g = point_1().operate_with(&g);
+
+        // let f1f2g_fixed = f1f2g_fixed();
+
+        assert_eq!(g.clone(), g.clone());
+
+        assert_eq!(f1f2.clone() , f1f2.clone());
+    }
+}

--- a/math/src/elliptic_curve/short_weierstrass/curves/bandersnatch/field_extension.rs
+++ b/math/src/elliptic_curve/short_weierstrass/curves/bandersnatch/field_extension.rs
@@ -18,7 +18,7 @@ pub struct FqConfig;
 /// Modulus of bandersnatch subgroup
 impl IsModulus<U256> for FqConfig {
     const MODULUS: U256 = U256::from_hex_unchecked(
-        "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001",
+        "73EDA753299D7D483339D80809A1D80553BDA402FFFE5BFEFFFFFFFF00000001",
     );
 }
 


### PR DESCRIPTION
Currently, it's giving an InvalidPoint error on f1f2. I took f1f2 parameters from arkworks impl. I also noticed that we've only put a base field and generator when defining the curve. Not sure if/how should we also add other things like:
```
//! * Scalar field: r =
//!   13108968793781547619861935127046491459309155893440570251786403306729687672801
//! * Valuation(q - 1, 2) = 32
//! * Valuation(r - 1, 2) = 5
//! * Curve equation: ax^2 + y^2 =1 + dx^2y^2, where
//!    * a = -5
//!    * d = 45022363124591815672509500913686876175488063829319466900776701791074614335719
```
Or the actual curve equation with parameters `a` and `d` is added just in ShortWeierstrass form(with `a` and `b`)?

But then seems we are still missing scalar field.

Also, I think parameters for new_base should be in hex format instead of dec.

ShortWeierstrass form is:
y^2 = x^3 + a * x + b

...will continue tomorrow


cc @MatteoMer @0xKitetsu-smdk lmk what do you think